### PR TITLE
Fix navigation support button

### DIFF
--- a/.eng
+++ b/.eng
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=https://prolog-api.profy.dev

--- a/.eng
+++ b/.eng
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_API_BASE_URL=https://prolog-api.profy.dev

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -138,4 +138,8 @@
   @media (min-width: breakpoint.$desktop) {
     display: flex;
   }
+
+  &.isCollapsed {
+    transform: rotate(180deg);
+  }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,10 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(
+                styles.collapseMenuItem,
+                isSidebarCollapsed && styles.isCollapsed,
+              )}
             />
           </ul>
         </nav>

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -83,7 +83,11 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={() =>
+                window.open(
+                  "mailto:support@prolog-app.com?subject=Support%20Request",
+                )
+              }
             />
             <MenuItemButton
               text="Collapse"

--- a/features/projects/components/project-card/project-card.module.scss
+++ b/features/projects/components/project-card/project-card.module.scss
@@ -19,7 +19,7 @@
 
 .bottomContainer {
   padding: space.$s4 space.$s6;
-  border-top: 3px solid color.$gray-200;
+  border-top: 2px solid color.$gray-200;
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
Fixed the navigation support button by removing the alert and adding a link to open the email client with an email to support@prolog-app.com with a subject of "Support Request"